### PR TITLE
Default date for the datepicker block

### DIFF
--- a/inc/Admin/DatePickerPostMeta.php
+++ b/inc/Admin/DatePickerPostMeta.php
@@ -53,7 +53,7 @@ class DatePickerPostMeta {
 
             // If the post has no date set then use the post date as a fallback
             if ( empty( $date ) ) {
-                $date = get_the_date( 'Ym', $post_id );
+                $date = strtotime(get_the_date( 'Ym', $post_id ));
             }
 
             // Add the date as post meta

--- a/src/event-date-time/index.js
+++ b/src/event-date-time/index.js
@@ -42,7 +42,11 @@ registerBlockType( 'co/event-date-time', {
 
         const { date_time } = attributes;
 
-        const saved_date = new Date(date_time);
+        if ( date_time !== null ) {
+            var saved_date = new Date(date_time);
+        } else {
+            var saved_date = new Date();
+        }
 
         const date_options = { day: 'numeric', month: 'long', year: 'numeric' };
 


### PR DESCRIPTION
Updating the date picker content block to use today's date as a default time, this will help when a user does not input a publication date correctly. 

This also includes a fix for the publication post meta to convert the date to a unix timestamp.

The Jira ticket can be found below:
https://affinity-digital.atlassian.net/browse/COSD-162
